### PR TITLE
disable impression events

### DIFF
--- a/client-sdk/UnlaunchClientBuilder.cs
+++ b/client-sdk/UnlaunchClientBuilder.cs
@@ -171,10 +171,10 @@ namespace io.unlaunch
             }
 
             var impressionApiRestClient = UnlaunchRestWrapper.Create(_sdkKey, _httpClientFactory.CreateClient(), _baseUrl, ImpressionApiPath, _connectionTimeout);
-            var impressionsEventHandler = new GenericEventHandler("metrics-impressions", impressionApiRestClient, _metricsFlushInterval, _metricsQueueSize);
+            var impressionsEventHandler = new GenericEventHandler("metrics-impressions", false, impressionApiRestClient, _metricsFlushInterval, _metricsQueueSize);
 
             var eventsApiRestClient = UnlaunchRestWrapper.Create(_sdkKey, _httpClientFactory.CreateClient(), _baseUrl, EventApiPath, _connectionTimeout);
-            var eventHandler = new GenericEventHandler("generic", eventsApiRestClient, _eventsFlushInterval, _eventsQueueSize);
+            var eventHandler = new GenericEventHandler("generic", true, eventsApiRestClient, _eventsFlushInterval, _eventsQueueSize);
             var variationsCountEventHandler = new CountAggregatorEventHandler(eventHandler, _metricsFlushInterval);
 
             return UnlaunchClient.Create(dataStore, eventHandler, variationsCountEventHandler, impressionsEventHandler,

--- a/client-sdk/events/AbstractEventHandler.cs
+++ b/client-sdk/events/AbstractEventHandler.cs
@@ -17,17 +17,20 @@ namespace io.unlaunch.events
         private readonly UnlaunchRestWrapper _restClient;
         private readonly AtomicBoolean _closed = new AtomicBoolean(false);
         private readonly string _name;
+        private readonly bool _enabled;
         private readonly int _maxBufferSize;
         private readonly AtomicLong _lastFlushInMillis = new AtomicLong(0);
         private readonly Timer _timer;
 
         public AbstractEventHandler(
             string name,
+            bool enabled,
             UnlaunchRestWrapper restClientForEventsApi,
             TimeSpan eventFlushInterval,
             int maxBufferSize)
         {
             _name = name;
+            _enabled = enabled;
             _restClient = restClientForEventsApi;
             _maxBufferSize = maxBufferSize;
 
@@ -36,7 +39,7 @@ namespace io.unlaunch.events
 
         public bool Handle(UnlaunchEvent unlaunchEvent)
         {
-            if (unlaunchEvent == null || _closed.Get())
+            if (!_enabled || unlaunchEvent == null || _closed.Get())
             {
                 return false;
             }

--- a/client-sdk/events/GenericEventHandler.cs
+++ b/client-sdk/events/GenericEventHandler.cs
@@ -6,9 +6,10 @@ namespace io.unlaunch.events
     {
         public GenericEventHandler(
             string name,
+            bool enabled,
             UnlaunchRestWrapper restClientForEventsApi,
             TimeSpan eventFlushInterval,
-            int maxBufferSize) : base(name, restClientForEventsApi, eventFlushInterval, maxBufferSize)
+            int maxBufferSize) : base(name, enabled, restClientForEventsApi, eventFlushInterval, maxBufferSize)
         {
 
         }


### PR DESCRIPTION
Currently leave Builder as it is, where users can adjust metricQueue size or metric flush interval. We would need to update our documentation not showing those.